### PR TITLE
Point to reveal.js from CDN

### DIFF
--- a/Bash_Lighting/add-reveal.js
+++ b/Bash_Lighting/add-reveal.js
@@ -1,0 +1,94 @@
+/* global hljs, Reveal */
+"use strict";
+
+function cdn(uri) {
+    var proto;
+
+    // Prefer HTTP
+    if (window.location.protocol == "https:") {
+        proto = "https:";
+    } else {
+        // Better caching
+        proto = "http:";
+    }
+
+    return proto + "//cdn.rawgit.com/hakimel/reveal.js/3.5.0/" + uri;
+}
+
+function addScript(uri) {
+    var script;
+    
+    script = document.createElement("script");
+    script.src = uri;
+    document.getElementsByTagName("head")[0].appendChild(script);
+}
+
+function addCss(rel) {
+    var link;
+
+    link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.type = "text/css";
+    link.href = rel;
+    document.getElementsByTagName("head")[0].appendChild(link);
+}
+
+function waitForReveal(callback) {
+    var startTime;
+
+    function check() {
+        // Allow 30 seconds
+        if (new Date() - startTime > 30000) {
+            console.error("Unable to find Reveal");
+        } else if (typeof Reveal !== "undefined") {
+            callback();
+        } else {
+            setTimeout(check, 10);
+        }
+    }
+
+    startTime = new Date();
+    check();
+}
+
+addCss(cdn("css/reveal.css"));
+addCss(cdn("css/theme/sky.css"));
+
+// Theme for syntax highlighting
+addCss(cdn("lib/css/zenburn.css"));
+
+// Printing and PDF exports
+if (window.location.search.match(/print-pdf/gi)) {
+    addCss(cdn("css/print/pdf.css"));
+} else {
+    addCss(cdn("css/print/paper.css"));
+}
+
+addScript(cdn("lib/js/head.min.js"));
+addScript(cdn("js/reveal.js"));
+waitForReveal(function () {
+    // More info //github.com/hakimel/reveal.js#configuration
+    Reveal.initialize({
+        history: true,
+        // More info //github.com/hakimel/reveal.js#dependencies
+        dependencies: [
+            {
+                src: cdn("plugin/markdown/marked.js")
+            },
+            {
+                src: cdn("plugin/markdown/markdown.js")
+            },
+            {
+                src: cdn("plugin/notes/notes.js"),
+                async: true
+            },
+            {
+                src: cdn("plugin/highlight/highlight.js"),
+                async: true,
+                callback: function () {
+                    hljs.initHighlightingOnLoad();
+                }
+            }
+        ]
+    });
+});

--- a/Bash_Lighting/add-reveal.js
+++ b/Bash_Lighting/add-reveal.js
@@ -84,7 +84,6 @@ waitForReveal(function () {
             },
             {
                 src: cdn("plugin/highlight/highlight.js"),
-                async: true,
                 callback: function () {
                     hljs.initHighlightingOnLoad();
                 }

--- a/Bash_Lighting/bash-lighting.html
+++ b/Bash_Lighting/bash-lighting.html
@@ -4,18 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Bash Tips Tricks Ignite</title>
-    <link rel="stylesheet" href="css/reveal.css">
-    <link rel="stylesheet" href="css/theme/sky.css">
-    <!-- Theme used for syntax highlighting of code -->
-    <link rel="stylesheet" href="lib/css/zenburn.css">
-    <!-- Printing and PDF exports -->
-    <script>
-      var link = document.createElement( 'link' );
-      link.rel = 'stylesheet';
-      link.type = 'text/css';
-      link.href = window.location.search.match( /print-pdf/gi ) ? 'css/print/pdf.css' : 'css/print/paper.css';
-      document.getElementsByTagName( 'head' )[0].appendChild( link );
-    </script>
+    <script src="add-reveal.js"></script>
   </head>
   <body>
     <div class="reveal">
@@ -477,21 +466,5 @@ exit 0
         </section>
       </div>
     </div>
-
-    <script src="lib/js/head.min.js"></script>
-    <script src="js/reveal.js"></script>
-    <script>
-      // More info https://github.com/hakimel/reveal.js#configuration
-      Reveal.initialize({
-      history: true,
-      // More info https://github.com/hakimel/reveal.js#dependencies
-      dependencies: [
-      { src: 'plugin/markdown/marked.js' },
-      { src: 'plugin/markdown/markdown.js' },
-      { src: 'plugin/notes/notes.js', async: true },
-      { src: 'plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } }
-      ]
-      });
-    </script>
   </body>
 </html>

--- a/CLI-Lighting/add-reveal.js
+++ b/CLI-Lighting/add-reveal.js
@@ -1,0 +1,94 @@
+/* global hljs, Reveal */
+"use strict";
+
+function cdn(uri) {
+    var proto;
+
+    // Prefer HTTP
+    if (window.location.protocol == "https:") {
+        proto = "https:";
+    } else {
+        // Better caching
+        proto = "http:";
+    }
+
+    return proto + "//cdn.rawgit.com/hakimel/reveal.js/3.5.0/" + uri;
+}
+
+function addScript(uri) {
+    var script;
+    
+    script = document.createElement("script");
+    script.src = uri;
+    document.getElementsByTagName("head")[0].appendChild(script);
+}
+
+function addCss(rel) {
+    var link;
+
+    link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.type = "text/css";
+    link.href = rel;
+    document.getElementsByTagName("head")[0].appendChild(link);
+}
+
+function waitForReveal(callback) {
+    var startTime;
+
+    function check() {
+        // Allow 30 seconds
+        if (new Date() - startTime > 30000) {
+            console.error("Unable to find Reveal");
+        } else if (typeof Reveal !== "undefined") {
+            callback();
+        } else {
+            setTimeout(check, 10);
+        }
+    }
+
+    startTime = new Date();
+    check();
+}
+
+addCss(cdn("css/reveal.css"));
+addCss(cdn("css/theme/sky.css"));
+
+// Theme for syntax highlighting
+addCss(cdn("lib/css/zenburn.css"));
+
+// Printing and PDF exports
+if (window.location.search.match(/print-pdf/gi)) {
+    addCss(cdn("css/print/pdf.css"));
+} else {
+    addCss(cdn("css/print/paper.css"));
+}
+
+addScript(cdn("lib/js/head.min.js"));
+addScript(cdn("js/reveal.js"));
+waitForReveal(function () {
+    // More info //github.com/hakimel/reveal.js#configuration
+    Reveal.initialize({
+        history: true,
+        // More info //github.com/hakimel/reveal.js#dependencies
+        dependencies: [
+            {
+                src: cdn("plugin/markdown/marked.js")
+            },
+            {
+                src: cdn("plugin/markdown/markdown.js")
+            },
+            {
+                src: cdn("plugin/notes/notes.js"),
+                async: true
+            },
+            {
+                src: cdn("plugin/highlight/highlight.js"),
+                async: true,
+                callback: function () {
+                    hljs.initHighlightingOnLoad();
+                }
+            }
+        ]
+    });
+});

--- a/CLI-Lighting/add-reveal.js
+++ b/CLI-Lighting/add-reveal.js
@@ -84,7 +84,6 @@ waitForReveal(function () {
             },
             {
                 src: cdn("plugin/highlight/highlight.js"),
-                async: true,
                 callback: function () {
                     hljs.initHighlightingOnLoad();
                 }

--- a/CLI-Lighting/cli-lighting.html
+++ b/CLI-Lighting/cli-lighting.html
@@ -4,18 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Command Lighting</title>
-    <link rel="stylesheet" href="css/reveal.css">
-    <link rel="stylesheet" href="css/theme/sky.css">
-    <!-- Theme used for syntax highlighting of code -->
-    <link rel="stylesheet" href="lib/css/zenburn.css">
-    <!-- Printing and PDF exports -->
-    <script>
-      var link = document.createElement( 'link' );
-      link.rel = 'stylesheet';
-      link.type = 'text/css';
-      link.href = window.location.search.match( /print-pdf/gi ) ? 'css/print/pdf.css' : 'css/print/paper.css';
-      document.getElementsByTagName( 'head' )[0].appendChild( link );
-    </script>
+    <script src="add-reveal.js"></script>
   </head>
   <body>
     <div class="reveal">
@@ -347,21 +336,5 @@ exit 0
         </section>
       </div>
     </div>
-
-    <script src="lib/js/head.min.js"></script>
-    <script src="js/reveal.js"></script>
-    <script>
-      // More info https://github.com/hakimel/reveal.js#configuration
-      Reveal.initialize({
-      history: true,
-      // More info https://github.com/hakimel/reveal.js#dependencies
-      dependencies: [
-      { src: 'plugin/markdown/marked.js' },
-      { src: 'plugin/markdown/markdown.js' },
-      { src: 'plugin/notes/notes.js', async: true },
-      { src: 'plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } }
-      ]
-      });
-    </script>
   </body>
 </html>

--- a/March_Bashness/March-Bashness.html
+++ b/March_Bashness/March-Bashness.html
@@ -4,18 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>March Bashness</title>
-    <link rel="stylesheet" href="css/reveal.css">
-    <link rel="stylesheet" href="css/theme/sky.css">
-    <!-- Theme used for syntax highlighting of code -->
-    <link rel="stylesheet" href="lib/css/zenburn.css">
-    <!-- Printing and PDF exports -->
-    <script>
-      var link = document.createElement( 'link' );
-      link.rel = 'stylesheet';
-      link.type = 'text/css';
-      link.href = window.location.search.match( /print-pdf/gi ) ? 'css/print/pdf.css' : 'css/print/paper.css';
-      document.getElementsByTagName( 'head' )[0].appendChild( link );
-    </script>
+    <script src="add-reveal.js"></script>
   </head>
   <body>
     <div class="reveal">
@@ -439,21 +428,5 @@ exit 0
         </section>
       </div>
     </div>
-
-    <script src="lib/js/head.min.js"></script>
-    <script src="js/reveal.js"></script>
-    <script>
-      // More info https://github.com/hakimel/reveal.js#configuration
-      Reveal.initialize({
-      history: true,
-      // More info https://github.com/hakimel/reveal.js#dependencies
-      dependencies: [
-      { src: 'plugin/markdown/marked.js' },
-      { src: 'plugin/markdown/markdown.js' },
-      { src: 'plugin/notes/notes.js', async: true },
-      { src: 'plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } }
-      ]
-      });
-    </script>
   </body>
 </html>

--- a/March_Bashness/add-reveal.js
+++ b/March_Bashness/add-reveal.js
@@ -1,0 +1,94 @@
+/* global hljs, Reveal */
+"use strict";
+
+function cdn(uri) {
+    var proto;
+
+    // Prefer HTTP
+    if (window.location.protocol == "https:") {
+        proto = "https:";
+    } else {
+        // Better caching
+        proto = "http:";
+    }
+
+    return proto + "//cdn.rawgit.com/hakimel/reveal.js/3.5.0/" + uri;
+}
+
+function addScript(uri) {
+    var script;
+    
+    script = document.createElement("script");
+    script.src = uri;
+    document.getElementsByTagName("head")[0].appendChild(script);
+}
+
+function addCss(rel) {
+    var link;
+
+    link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.type = "text/css";
+    link.href = rel;
+    document.getElementsByTagName("head")[0].appendChild(link);
+}
+
+function waitForReveal(callback) {
+    var startTime;
+
+    function check() {
+        // Allow 30 seconds
+        if (new Date() - startTime > 30000) {
+            console.error("Unable to find Reveal");
+        } else if (typeof Reveal !== "undefined") {
+            callback();
+        } else {
+            setTimeout(check, 10);
+        }
+    }
+
+    startTime = new Date();
+    check();
+}
+
+addCss(cdn("css/reveal.css"));
+addCss(cdn("css/theme/sky.css"));
+
+// Theme for syntax highlighting
+addCss(cdn("lib/css/zenburn.css"));
+
+// Printing and PDF exports
+if (window.location.search.match(/print-pdf/gi)) {
+    addCss(cdn("css/print/pdf.css"));
+} else {
+    addCss(cdn("css/print/paper.css"));
+}
+
+addScript(cdn("lib/js/head.min.js"));
+addScript(cdn("js/reveal.js"));
+waitForReveal(function () {
+    // More info //github.com/hakimel/reveal.js#configuration
+    Reveal.initialize({
+        history: true,
+        // More info //github.com/hakimel/reveal.js#dependencies
+        dependencies: [
+            {
+                src: cdn("plugin/markdown/marked.js")
+            },
+            {
+                src: cdn("plugin/markdown/markdown.js")
+            },
+            {
+                src: cdn("plugin/notes/notes.js"),
+                async: true
+            },
+            {
+                src: cdn("plugin/highlight/highlight.js"),
+                async: true,
+                callback: function () {
+                    hljs.initHighlightingOnLoad();
+                }
+            }
+        ]
+    });
+});

--- a/March_Bashness/add-reveal.js
+++ b/March_Bashness/add-reveal.js
@@ -84,7 +84,6 @@ waitForReveal(function () {
             },
             {
                 src: cdn("plugin/highlight/highlight.js"),
-                async: true,
                 callback: function () {
                     hljs.initHighlightingOnLoad();
                 }


### PR DESCRIPTION
This allows the slides to work even when ran directly in a browser or
when someone (like myself) clones the repository.

Also pulled out reveal.js init code into separate file to make it easier
to change the CDN if needed.